### PR TITLE
Running of tests when building OpenSSL

### DIFF
--- a/docker/openssl-mingw/Dockerfile
+++ b/docker/openssl-mingw/Dockerfile
@@ -8,6 +8,7 @@ FROM abrarov/mingw:2.3.0
 
 ENV OPENSSL_VERSION=1.0.2q \
     OPENSSL_URL=https://www.openssl.org/source \
+    OPENSSL_TEST="" \
     SCRIPT_DIR=C:\\app
 
 ADD ["app", "C:/app/"]

--- a/docker/openssl-mingw/app/build.bat
+++ b/docker/openssl-mingw/app/build.bat
@@ -30,6 +30,12 @@ make
 set exit_code=%errorlevel%
 if %exit_code% neq 0 goto exit
 
+if not "--%OPENSSL_TEST%" == "--" (
+  make test
+  set exit_code=%errorlevel%
+  if %exit_code% neq 0 goto exit
+)
+
 make install
 set exit_code=%errorlevel%
 if %exit_code% neq 0 goto exit

--- a/docker/openssl-mingw/app/patches/openssl-1.0.2q.patch
+++ b/docker/openssl-mingw/app/patches/openssl-1.0.2q.patch
@@ -1,0 +1,89 @@
+--- ./util/mk1mf.pl	2019-02-13 21:00:00 +0300
++++ ./util/mk1mf.pl	2019-02-13 21:10:00 +0300
+@@ -1236,6 +1236,8 @@
+ 		"shlib" => \$shlib,
+ 		"dll" => \$shlib,
+ 		"shared" => 0,
+++		"debug_lib" => \$debug_lib,
+++		"static_lib" => \$static_lib,
+ 		"no-sctp" => 0,
+ 		"no-srtp" => 0,
+ 		"no-gmp" => 0,
+
+--- ./util/mkdef.pl	2019-02-13 21:00:00 +0300
++++ ./util/mkdef.pl	2019-02-13 21:10:00 +0300
+@@ -55,6 +55,8 @@
+ #
+
+ my $debug=0;
++my $debug_lib=0;
++my $static_lib=0;
+
+ my $crypto_num= "util/libeay.num";
+ my $ssl_num=    "util/ssleay.num";
+@@ -157,6 +159,8 @@
+ foreach (@ARGV, split(/ /, $options))
+ 	{
+ 	$debug=1 if $_ eq "debug";
++	$debug_lib=1 if $_ eq "debug_lib";
++	$static_lib=1 if $_ eq "static_lib";
+ 	$W32=1 if $_ eq "32";
+ 	$W16=1 if $_ eq "16";
+ 	if($_ eq "NT") {
+@@ -1323,6 +1327,19 @@
+ 		  $description = "\@#$http_vendor:$version#\@$what; DLL for library $name.  Build for EMX -Zmtd";
+ 		}
+
++	$libsuffix="";
++	if ($static_lib) {
++		$libsuffix="MT";
++	} else {
++		$libsuffix="MD";
++	}
++
++	if ($debug_lib) {
++		$libsuffix=$libsuffix."d";
++	}
++
++	$libname=$libname.$libsuffix;
++
+ 	print OUT <<"EOF";
+ ;
+ ; Definition file for the DLL version of the $name library from OpenSSL
+
+--- ./util/pl/VC-32.pl	2019-02-13 21:00:00 +0300
++++ ./util/pl/VC-32.pl	2019-02-13 21:10:00 +0300
+@@ -16,6 +16,20 @@
+ 	$crypto="libeay32";
+ 	}
+
++$libsuffix="";
++if ($static_lib) {
++	$libsuffix="MT";
++} else {
++	$libsuffix="MD";
++}
++
++if ($debug_lib) {
++	$libsuffix=$libsuffix."d";
++}
++
++$ssl=$ssl.$libsuffix;
++$crypto=$crypto.$libsuffix;
++
+ $o='\\';
+ $cp='$(PERL) util/copy.pl';
+ $mkdir='$(PERL) util/mkdir-p.pl';
+@@ -154,9 +168,9 @@
+ 	$cflags=$opt_cflags.$base_cflags;
+ 	}
+
+-# generate symbols.pdb unconditionally
+-$app_cflag.=" /Zi /Fd\$(TMP_D)/app";
+-$lib_cflag.=" /Zi /Fd\$(TMP_D)/lib";
++# Do not generate symbols.pdb because it depends on path used for building and that path is incorporated into PDB
++$app_cflag.=" /Zi";
++$lib_cflag.=" /Zi";
+ $lflags.=" /debug";
+
+ $obj='.obj';

--- a/docker/openssl-msvc-2015/Dockerfile
+++ b/docker/openssl-msvc-2015/Dockerfile
@@ -8,6 +8,7 @@ FROM abrarov/msvc-2015:2.3.0
 
 ENV OPENSSL_VERSION=1.0.2q \
     OPENSSL_URL=https://www.openssl.org/source \
+    OPENSSL_TEST="" \
     SCRIPT_DIR=C:\\app
 
 ADD ["app", "C:/app/"]

--- a/docker/openssl-msvc-2015/app/build.bat
+++ b/docker/openssl-msvc-2015/app/build.bat
@@ -56,7 +56,19 @@ perl util\mkdef.pl %OPENSSL_BUILD_STR% %OPENSSL_LINK_STR% 32 ssleay > ms\ssleay3
 set exit_code=%errorlevel%
 if %exit_code% neq 0 goto exit
 
-nmake -f "%OPENSSL_HOME%\ms\nt%OPENSSL_DLL_STR%-%OPENSSL_ARCH%.mak" install
+set "make_file=%OPENSSL_HOME%\ms\nt%OPENSSL_DLL_STR%-%OPENSSL_ARCH%.mak"
+
+nmake -f "%make_file%"
+set exit_code=%errorlevel%
+if %exit_code% neq 0 goto exit
+
+if not "--%OPENSSL_TEST%" == "--" (
+  nmake -f "%make_file%" test
+  set exit_code=%errorlevel%
+  if %exit_code% neq 0 goto exit
+)
+
+nmake -f "%make_file%" install
 set exit_code=%errorlevel%
 if %exit_code% neq 0 goto exit
 

--- a/docker/openssl-msvc-2017/Dockerfile
+++ b/docker/openssl-msvc-2017/Dockerfile
@@ -8,6 +8,7 @@ FROM abrarov/msvc-2017:2.3.0
 
 ENV OPENSSL_VERSION=1.0.2q \
     OPENSSL_URL=https://www.openssl.org/source \
+    OPENSSL_TEST="" \
     SCRIPT_DIR=C:\\app
 
 ADD ["app", "C:/app/"]

--- a/docker/openssl-msvc-2017/app/build.bat
+++ b/docker/openssl-msvc-2017/app/build.bat
@@ -56,7 +56,19 @@ perl util\mkdef.pl %OPENSSL_BUILD_STR% %OPENSSL_LINK_STR% 32 ssleay > ms\ssleay3
 set exit_code=%errorlevel%
 if %exit_code% neq 0 goto exit
 
-nmake -f "%OPENSSL_HOME%\ms\nt%OPENSSL_DLL_STR%-%OPENSSL_ARCH%.mak" install
+set "make_file=%OPENSSL_HOME%\ms\nt%OPENSSL_DLL_STR%-%OPENSSL_ARCH%.mak"
+
+nmake -f "%make_file%"
+set exit_code=%errorlevel%
+if %exit_code% neq 0 goto exit
+
+if not "--%OPENSSL_TEST%" == "--" (
+  nmake -f "%make_file%" test
+  set exit_code=%errorlevel%
+  if %exit_code% neq 0 goto exit
+)
+
+nmake -f "%make_file%" install
 set exit_code=%errorlevel%
 if %exit_code% neq 0 goto exit
 


### PR DESCRIPTION
Optional running of tests when building OpenSSL (use OPENSSL_TEST environment variable with non-empty value to trigger execution of tests)